### PR TITLE
Implemented forgot password functionality

### DIFF
--- a/app/src/pages/login.tsx
+++ b/app/src/pages/login.tsx
@@ -12,6 +12,7 @@ import { useRouter } from "next/router";
 const LoginPage = () => {
   const ref = useRef<HTMLFormElement>(null);
   const [forgotPassword, setForgotPassword] = useState(false);
+  const [checkInbox, setCheckInbox] = useState(false);
   const [width, setWidth] = useState(0);
   const [height, setHeight] = useState(0);
   const [email, setEmail] = useState("");
@@ -46,8 +47,13 @@ const LoginPage = () => {
       });
   };
 
-  const handleForgotPassword = async (e: FormEvent<HTMLFormElement>) => {
+  useEffect(() => {
+    setCheckInbox(false)
+  }, [forgotPassword, false]);
+
+  const handleForgotPassword = async () => {
     sendResetEmail(email);
+    setCheckInbox(true);
   };
 
   return (
@@ -57,7 +63,7 @@ const LoginPage = () => {
           className={`${styles.form} ${styles.forgot}`}
           onSubmit={(e) => {
             e.preventDefault();
-            handleForgotPassword(e);
+            handleForgotPassword();
           }}
           style={{ width: width, height: height }}
         >
@@ -84,6 +90,11 @@ const LoginPage = () => {
             />
             Submit
           </button>
+          {checkInbox ? (<div className={styles.checkInbox}><p>Please check your inbox.</p><span onClick={() =>
+            setForgotPassword(false)}>
+            Return to login.
+          </span></div>
+          ) : <div></div>}
         </form>
       ) : (
         <form

--- a/app/src/pages/login.tsx
+++ b/app/src/pages/login.tsx
@@ -47,7 +47,7 @@ const LoginPage = () => {
   };
 
   const handleForgotPassword = async (e: FormEvent<HTMLFormElement>) => {
-    sendResetEmail("randomEmail");
+    sendResetEmail(email);
   };
 
   return (

--- a/app/src/styles/login.module.css
+++ b/app/src/styles/login.module.css
@@ -16,7 +16,7 @@
     flex-direction: column;
     align-items: center;
     gap: 16px;
-    max-width: 520px;
+    width: 500px;
     margin: 16px;
     padding: 24px 32px;
     border-radius: 10px;
@@ -24,7 +24,7 @@
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.5);
 }
 
-.form > img:first-of-type {
+.form>img:first-of-type {
     position: absolute;
     top: -100px;
     width: auto;
@@ -43,14 +43,14 @@
     width: 100%;
 }
 
-.password > span {
+.password>span {
     font-size: 20px;
     text-align: right;
     color: #122286;
     cursor: pointer;
 }
 
-.form > input {
+.form>input {
     width: 100%;
     height: 48px;
     border: none;
@@ -61,7 +61,7 @@
     background: white;
 }
 
-.form > button {
+.form>button {
     display: flex;
     justify-content: center;
     align-items: center;
@@ -76,17 +76,17 @@
     font-size: 28px;
 }
 
-.form > button > img {
+.form>button>img {
     width: auto;
     height: 40px;
 }
 
-.form > span {
+.form>span {
     font-size: 20px;
     text-align: center;
 }
 
-.form > span > a {
+.form>span>a {
     font-size: 20px;
     color: #000c79;
     text-decoration: underline;
@@ -106,4 +106,15 @@
     right: 12px;
     width: auto;
     height: 36px;
+    cursor: pointer;
+}
+
+.checkInbox>p {
+    font-size: 20px;
+}
+
+.checkInbox>span {
+    font-size: 20px;
+    color: #122286;
+    cursor: pointer;
 }


### PR DESCRIPTION
Previously when a user forgot their password, nothing would happen after entering their email and hitting the submit button in request for a password reset.

![image](https://github.com/user-attachments/assets/c36e6693-9bff-4111-b791-ce7329e692aa)

![image](https://github.com/user-attachments/assets/3172f7f4-0a7e-41a1-a940-8a59ae00794d)

Therefore, I implemented the functionality to where now when the user enters their email and hits `Submit`, a password reset email is sent to their inbox. A pop up message is also displayed below the `Submit` button to inform the user of checking their inbox, as well as the option of returning to the login page.

![Screenshot 2024-10-10 231144](https://github.com/user-attachments/assets/34a7730b-8e92-4a48-8ef9-eab1e8bb299b)
![image](https://github.com/user-attachments/assets/7c62532c-2562-4466-a67f-a23b8c608c34)

Size of login window was also adjusted to fix formatting.

![image](https://github.com/user-attachments/assets/aa98a73b-140e-4c21-873d-bad58980a382)

